### PR TITLE
add limit and sort options to OptionValue.get APIv3

### DIFF
--- a/CRM/Textselect/Util.php
+++ b/CRM/Textselect/Util.php
@@ -21,6 +21,7 @@ class CRM_Textselect_Util {
       $result = civicrm_api3('OptionValue', 'get', [
         'sequential' => 1,
         'option_group_id' => $setting['option_group_id'],
+        'options' => ['limit' => 0, 'sort' => 'weight'],
       ]);
       $allFieldOptions[$setting['field_id']] = $result['values'];
     }


### PR DESCRIPTION
see #11 

Previously the select showed a maximum of 25 options and was not sorted according to weight.
