### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/TextSelectConfig.php
+++ b/api/v3/TextSelectConfig.php
@@ -18,7 +18,6 @@ function _civicrm_api3_text_select_config_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -29,7 +28,6 @@ function civicrm_api3_text_select_config_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -40,7 +38,6 @@ function civicrm_api3_text_select_config_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/TextSelectConfig.php
+++ b/api/v3/TextSelectConfig.php
@@ -18,7 +18,7 @@ function _civicrm_api3_text_select_config_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -29,7 +29,7 @@ function civicrm_api3_text_select_config_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -40,7 +40,7 @@ function civicrm_api3_text_select_config_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_text_select_config_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.